### PR TITLE
Travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: ruby

--- a/Rakefile
+++ b/Rakefile
@@ -21,3 +21,12 @@ end
 require 'rake'
 
 require 'bundler/gem_tasks'
+
+begin
+  require 'rspec/core/rake_task'
+
+  RSpec::Core::RakeTask.new(:spec)
+
+  task default: :spec
+rescue LoadError
+end


### PR DESCRIPTION
### Description of the Change

This seeks to configure a default `rake` task which runs the RSpec tests, as well as to wire up the configuration for TravisCI continuous integration.

### Alternate Designs

While other CI systems exist, TravisCI is one of the more popular, widely used, and easy to integrate amongst open source projects.

### Why Should This Be In The Gem?

Continuous integration works to help automate quality insurance as changes are introduced to the gem.

### Benefits

By configuring a default `rake` task and TravisCI CI, contributors and users are able to easily view the gem's build status, and also to easily understand how best to validate their own contributions and changes.

### Possible Drawbacks

This will require that TravisCI integration be enabled and maintained. Further changes may be necessary down the road pending how this performs in TravisCI, though I presently have no visibility until TravisCI is wired up.

### Verification Process

I validated that the following installs gems and runs tests; this is presumably the same action TravisCI takes:

```
bundle install
bundle exec rake
```

### Applicable Issues (Optional)

Presently, the tests appear to assume the presence of an environment variable which, when absent, causes test failures, IIUC:

```
An error occurred while loading ./spec/zone_spec.rb.
Failure/Error:
  @signer = Aws::Sigv4::Signer.new(
      service: 'VinylDNS',
      region: 'us-east-1',
      access_key_id: ENV['VINYLDNS_ACCESS_KEY_ID'],
      secret_access_key: ENV['VINYLDNS_SECRET_ACCESS_KEY'],
      apply_checksum_header: false # Required for posting body in make_request : http://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/Sigv4/Signer.html : If the 'X-Amz-Content-Sha256' header is set, the :body is optional and will not be read.
  )

ArgumentError:
  expected both :access_key_id and :secret_access_key options
# /Users/mball0001/.rvm/gems/ruby-2.4.1/gems/aws-sigv4-1.0.3/lib/aws-sigv4/credentials.rb:18:in `initialize'
# /Users/mball0001/.rvm/gems/ruby-2.4.1/gems/aws-sigv4-1.0.3/lib/aws-sigv4/credentials.rb:50:in `new'
# /Users/mball0001/.rvm/gems/ruby-2.4.1/gems/aws-sigv4-1.0.3/lib/aws-sigv4/credentials.rb:50:in `initialize'
# /Users/mball0001/.rvm/gems/ruby-2.4.1/gems/aws-sigv4-1.0.3/lib/aws-sigv4/signer.rb:515:in `new'
# /Users/mball0001/.rvm/gems/ruby-2.4.1/gems/aws-sigv4-1.0.3/lib/aws-sigv4/signer.rb:515:in `extract_credentials_provider'
# /Users/mball0001/.rvm/gems/ruby-2.4.1/gems/aws-sigv4-1.0.3/lib/aws-sigv4/signer.rb:121:in `initialize'
# ./lib/vinyldns/api.rb:34:in `new'
# ./lib/vinyldns/api.rb:34:in `initialize'
# ./lib/vinyldns/api/zone/zone.rb:53:in `new'
# ./lib/vinyldns/api/zone/zone.rb:53:in `search'
# ./spec/zone_spec.rb:13:in `block in <top (required)>'
# ./spec/zone_spec.rb:11:in `<top (required)>'

Finished in 0.00018 seconds (files took 0.21148 seconds to load)
0 examples, 0 failures, 2 errors occurred outside of examples
```