### PR TITLE
Use ruby rspec convention in group spec

### DIFF
--- a/spec/group_spec.rb
+++ b/spec/group_spec.rb
@@ -8,8 +8,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 require 'spec_helper'
-RSpec.describe Vinyldns::API::Group do
-  first_group = Vinyldns::API::Group.list_my_groups['groups'].first
+
+describe Vinyldns::API::Group do
+
+  let(:first_group) do
+    # A group is expected to exist for now
+    Vinyldns::API::Group.list_my_groups['groups'].first
+  end
 
   describe '.create' do
     it 'can POST & receives 409 Conflict connecting to an already existing group' do


### PR DESCRIPTION
Use rspecisms

I would have liked to take this refactor further but still exploring how vinyl works.

```
➜ ~/c/vinyldns-ruby git:(rspec-group-spec) ✗ bundle exec rspec spec/group_spec.rb

Vinyldns::API::Group
  .create
    can POST & receives 409 Conflict connecting to an already existing group
  .update
    can PUT & receives 400 Bad Request with "Missing Group"
    raises error when request_params argument is not hash
  .get
    does not raise an error
  .list_my_groups
    does not raise an error
    returns something
  .list_group_admins
    does not raise an error
  .list_group_members
    does not raise an error
  .get_group_activity
    does not raise an error

Finished in 4.49 seconds (files took 0.39254 seconds to load)
9 examples, 0 failures

```