### PR TITLE
only start api in start_api script

### DIFF
--- a/scripts/start_api
+++ b/scripts/start_api
@@ -2,4 +2,4 @@
 
 mkdir -p ./api
 git clone https://github.com/vinyldns/vinyldns ./api/
-./api/bin/docker-up-vinyldns.sh
+./api/bin/docker-up-api-server.sh


### PR DESCRIPTION
I often encounter timeout issues when running the `make start-api` task. It currently tries to start all of VinylDNS (the API and portal) when the ruby client only needs to interact with the API. Changed the script to run the VinylDNS API start script only.